### PR TITLE
Cleans up .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,6 @@ yarn-error.log*
 dist/
 *.tsbuildinfo
 
-# Output files
-subscription/
-test/output/
-
 # IDE files
 .vscode/
 .idea/


### PR DESCRIPTION
Removes unnecessary entries from the .gitignore file, specifically output directories that are likely already covered by broader rules. This simplifies the file and reduces the chance of inadvertently ignoring important files.